### PR TITLE
Implemented restart hot-key and logic for both client and server

### DIFF
--- a/Frame.hpp
+++ b/Frame.hpp
@@ -23,6 +23,7 @@ namespace cse125framing {
 		int ctr;
 		MovementKey movementKey;
 		vec3 cameraDirection;
+		bool replayMatch = false; // whether this client is ready to replay another match
 	} ClientFrame;
 
 	enum class AudioId {
@@ -60,6 +61,7 @@ namespace cse125framing {
 		AudioTrigger audio[cse125constants::MAX_NUM_SOUNDS];
 		AnimationTrigger animations;
 		RealNumber gameTime;
+		bool matchInProgress = true;
 	} ServerFrame;
 
 	const size_t CLIENT_FRAME_BUFFER_SIZE = sizeof(ClientFrame);

--- a/GameLogic/PhysicalObjectManager.cpp
+++ b/GameLogic/PhysicalObjectManager.cpp
@@ -86,12 +86,13 @@ void PhysicalObjectManager::createObject(int objType, glm::vec3 pos, glm::vec3 d
 	// this->objects->push_back(new PhysicalObject(objects, glm::vec3(0.0f), 1.0f, 1.0f, 1.0f, glm::vec3(0.0f, 0.0f, 1.0f), glm::vec3(0.0f, 1.0f, 0.0f), next_id, true));
 }
 
-void PhysicalObjectManager::step() {
+void PhysicalObjectManager::step(bool* matchInProgress) {
 	if (gameTime > 0.0f) {
 		gameTime -= 1.0f / cse125config::DEFAULT_TICK_RATE;
 		if (gameTime <= 0.0f) {
 			gameTime = 0.0f;
 			endGame();
+			*matchInProgress = false;
 		}
 	}
 	for (unsigned int i = 0; i < objects->size(); i++) {

--- a/GameLogic/PhysicalObjectManager.hpp
+++ b/GameLogic/PhysicalObjectManager.hpp
@@ -36,8 +36,13 @@ public:
 	// Create an instance
 	void createObject(int objType, glm::vec3 pos, glm::vec3 dir, glm::vec3 up = glm::vec3(0.0f, 1.0f, 0.0f));
 
-	// Update general game state once per tick
-	void step();
+
+	/**
+	 * @brief Update general game state once per tick 
+	 *
+	 * @param matchInProgress will be set to false if the game has ended, unchanged otherwise
+	 */
+	void step(bool* matchInProgress);
 	
 	// These will not be used for now
 	vector<vector<int>*>* createGrid(glm::vec3 gridMin, glm::vec3 gridMax, glm::vec3 gridSizes);

--- a/server/GameUtils.cpp
+++ b/server/GameUtils.cpp
@@ -29,6 +29,9 @@ void initializeServerFrame(PhysicalObjectManager* manager,
         frame->players[id].playerPosition = vec4(player->position, 1.0f);
         frame->players[id].score = player->score;
     }
+
+    // set game restart values
+    frame->matchInProgress = true;
 }
 
 // Initializes and returns the PhysicalObjectManager

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -126,10 +126,8 @@ int main()
 
         std::cerr << "Match has ended!" << std::endl;
 
-        // Reset game state
+        // Reset the game manager
         delete manager;
-
-        std::cerr << "Deleted manager!" << std::endl;
 
         // Tell clients that the match finished
         cse125framing::ServerFrame matchFinishedFrame;
@@ -144,6 +142,11 @@ int main()
 
         // Reset number of clients replaying
         server->resetReplayStatus();
+
+        // Reset the server packet queue
+        server->queueMtx.lock();
+        server->serverQueue.clear();
+        server->queueMtx.unlock();
 
         // All clients are ready: notify clients that the game has restarted
         cse125framing::ServerFrame matchRestartedFrame;

--- a/server/main.cpp
+++ b/server/main.cpp
@@ -13,6 +13,8 @@
 
 PhysicalObjectManager* manager;
 boost::asio::io_context io_context;
+bool matchInProgress = true;
+bool runServer = true;
 
 void launchServer()
 {
@@ -20,11 +22,12 @@ void launchServer()
     io_context.run();
 }
 
+
+
 int main()
 {
     // Initialize server and game
     cse125config::initializeConfig("../config.json");
-    manager = initializeGame();
     GraphicsServer* server =
         new GraphicsServer(io_context, std::stoi(cse125config::SERVER_PORT));
     boost::thread serverThread(launchServer);
@@ -40,13 +43,15 @@ int main()
     {
         // idle wait for clients
     }
-
-    std::cout << "Starting Skrrt Skirt!" << std::endl;
-
     // server loop
-    try
+ 
+    while (runServer) 
     {
-        while (true)
+        // Initialize or re-initialize game manager
+        manager = initializeGame();
+        matchInProgress = true;
+        std::cout << "Starting Skrrt Skirt!" << std::endl;
+        while (matchInProgress)
         {
             // Start the clock tick
             ticker.tickStart();
@@ -66,13 +71,13 @@ int main()
             // Iterate from the end of where the queue currently is to the
             // beginning
             for (auto it = serverQueue.crbegin(); it != serverQueue.crend();
-                 it++)
+                it++)
             {
                 const cse125framing::ClientFrame& clientFrame = *it;
 
                 gameActionTracker.setAction(clientFrame.id,
-                                            clientFrame.movementKey,
-                                            clientFrame.cameraDirection);
+                    clientFrame.movementKey,
+                    clientFrame.cameraDirection);
 
                 // Track the priority order for this player
                 // Note: Higher values indicate higher priority
@@ -93,11 +98,11 @@ int main()
             }
 
             // Update basic game state (score, makeup levels; not dependent on input)
-            manager->step();
+            manager->step(&matchInProgress);
 
             // Update the game state in player priority order
             for (auto it = sortedPriorities.begin();
-                 it != sortedPriorities.end(); it++)
+                it != sortedPriorities.end(); it++)
             {
                 const int& playerId = it->second;
 
@@ -108,24 +113,46 @@ int main()
                     cse125gameaction::gameActionFromContainer(container);
 
                 gameLoop(manager, playerId, gameAction,
-                         container->cameraDirection);
+                    container->cameraDirection);
             }
 
             // Write data back to players
             cse125framing::ServerFrame serverFrame;
             initializeServerFrame(manager, &serverFrame);
             server->writePackets(&serverFrame);
-
             // Sleep until the end of the clock tick
             ticker.tickEnd();
         }
-    }
-    catch (std::exception& e)
-    {
-        std::cerr << e.what() << std::endl;
-    }
 
-    delete manager;
+        std::cerr << "Match has ended!" << std::endl;
+
+        // Reset game state
+        delete manager;
+
+        std::cerr << "Deleted manager!" << std::endl;
+
+        // Tell clients that the match finished
+        cse125framing::ServerFrame matchFinishedFrame;
+        matchFinishedFrame.matchInProgress = false;
+        server->writePackets(&matchFinishedFrame);
+
+        // Wait for all clients to be ready to play again
+        std::cerr << "Waiting for clients to restart..." << std::endl;
+        while (!server->readyToReplay()) {
+            // Idle wait
+        }
+
+        // Reset number of clients replaying
+        server->resetReplayStatus();
+
+        // All clients are ready: notify clients that the game has restarted
+        cse125framing::ServerFrame matchRestartedFrame;
+        matchRestartedFrame.matchInProgress = true;
+
+        std::cerr << "All clients ready to restart! Notifying clients..." << std::endl;
+        server->writePackets(&matchRestartedFrame);
+    }  
+
     // Wait for the server thread to finish
     serverThread.join();
 

--- a/skrrt/Game/HW3.vcxproj
+++ b/skrrt/Game/HW3.vcxproj
@@ -86,6 +86,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\Config.cpp" />
     <ClCompile Include="..\..\Frame.cpp" />
+    <ClCompile Include="include\Debug.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="src\Animation.cpp" />
     <ClCompile Include="src\Camera.cpp" />

--- a/skrrt/Game/HW3.vcxproj.filters
+++ b/skrrt/Game/HW3.vcxproj.filters
@@ -4,6 +4,7 @@
     <ClCompile Include="..\..\Config.cpp" />
     <ClCompile Include="..\..\Frame.cpp" />
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="src\Animation.cpp" />
     <ClCompile Include="src\Camera.cpp" />
     <ClCompile Include="src\Game.cpp" />
     <ClCompile Include="src\NetworkClient.cpp" />
@@ -16,13 +17,14 @@
     <ClCompile Include="src\Scene.cpp" />
     <ClCompile Include="src\Shader.cpp" />
     <ClCompile Include="src\stb_image.cpp" />
-    <ClCompile Include="src\Animation.cpp" />
+    <ClCompile Include="include\Debug.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\Config.hpp" />
     <ClInclude Include="..\..\Constants.hpp" />
     <ClInclude Include="..\..\Definitions.hpp" />
     <ClInclude Include="..\..\Frame.hpp" />
+    <ClInclude Include="include\Animation.h" />
     <ClInclude Include="include\Camera.h" />
     <ClInclude Include="include\Cube.h" />
     <ClInclude Include="include\Debug.h" />
@@ -45,11 +47,7 @@
     <ClInclude Include="include\Shader.h" />
     <ClInclude Include="include\stb_image.h" />
     <ClInclude Include="include\SurfaceShader.h" />
-<<<<<<< HEAD
-    <ClInclude Include="include\Animation.h" />
-=======
     <ClInclude Include="include\TextureConstants.h" />
->>>>>>> 4293b9a7c1ff82a6992cdc6388dbb88dc66f335d
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/skrrt/Game/include/Debug.cpp
+++ b/skrrt/Game/include/Debug.cpp
@@ -1,0 +1,7 @@
+#include "Debug.h"
+
+void cse125debug::log(int level, const char* msg) {
+	if (level >= DEBUG_LEVEL) {
+		std::cerr << msg;
+	}
+}

--- a/skrrt/Game/include/Debug.h
+++ b/skrrt/Game/include/Debug.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <iostream>
 #define LOG_LEVEL_NONE 0
 #define LOG_LEVEL_ERROR 1 
 #define LOG_LEVEL_WARN 2
@@ -7,7 +8,7 @@
 #define LOG_LEVEL_FINER 5
 #define LOG_LEVEL_FINEST 6
  
-#define DEBUG_LEVEL LOG_LEVEL_INFO
+#define DEBUG_LEVEL LOG_LEVEL_WARN
 
 // How to use debug level: 
 // if(DEBUG_LEVEL >= LOG_LEVEL_<whatever>) {
@@ -18,3 +19,7 @@
 
 // This is for utilizing the top down view of the game 
 #define TOP_DOWN_VIEW false
+
+namespace cse125debug {
+	void log(int level, const char* msg);
+}

--- a/skrrt/Game/include/NetworkClient.hpp
+++ b/skrrt/Game/include/NetworkClient.hpp
@@ -46,6 +46,15 @@ namespace cse125networkclient {
 
 
 		/**
+		 * @brief Sends a ClientFrame to the server indicating that this player is ready to replay a match
+		 *
+		 * @param errorCode			the error (if any) set by the network call
+		 * 
+		 * @return the number of bytes successfully sent
+		 */
+		size_t replay(boost::system::error_code* errorCode);
+
+		/**
 		 * @brief Closes the connection established by this object
 		 */
 		void closeConnection();

--- a/skrrt/Game/main.cpp
+++ b/skrrt/Game/main.cpp
@@ -28,8 +28,8 @@
 #include "../../Definitions.hpp"
 #include "Debug.h"
 
-static const int width = 1200;
-static const int height = 900;
+static const int width = 900;
+static const int height = 600;
 static const char* title = "Scene viewer";
 static const glm::vec4 background(0.1f, 0.2f, 0.3f, 1.0f);
 static Scene scene;
@@ -49,6 +49,10 @@ static int particleTime = 0;
 int clientId = cse125constants::DEFAULT_CLIENT_ID; // this client's unique id
 std::unique_ptr<cse125networkclient::NetworkClient> networkClient;
 
+// Game restart variables
+bool matchInProgress = false;
+bool readyToReplay = false;
+
 // Time
 static std::chrono::time_point<std::chrono::system_clock> startTime;
 
@@ -61,8 +65,27 @@ static bool mouseLocked = true;
 
 void sendDataToServer(MovementKey movementKey, vec3 cameraDirection)
 {
-    boost::system::error_code error;
-    size_t numWritten = networkClient->send(movementKey, cameraDirection, &error);
+    // Only send data to server if the match is in progress
+    if (matchInProgress) {
+        boost::system::error_code error;
+        size_t numWritten = networkClient->send(movementKey, cameraDirection, &error);
+    }
+}
+
+void sendReplayToServer() {
+    // Only allow replay packet to be sent when match is not in progress 
+     // and if it hasn't been sent already
+    if (!matchInProgress && !readyToReplay) {
+        // Send packet to server indicating client is ready to replay
+        boost::system::error_code error;
+        // Check for a packet from the server indicating that the game is ready to restart
+        cse125debug::log(LOG_LEVEL_INFO, "Sending replay packet to server...\n");        
+        networkClient->replay(&error);
+        if (!error) {
+            readyToReplay = true;
+            cse125debug::log(LOG_LEVEL_INFO, "Successfully sent replay packet to server...\n");
+        }
+    }
 }
 
 cse125framing::ServerFrame* receiveDataFromServer()
@@ -106,7 +129,7 @@ void printHelp(){
       press 'O' to save a screenshot.
       press the arrow keys to rotate camera.
       press 'Z' to zoom.
-      press 'R' to reset camera.
+      press 'C' to reset camera.
       press 'L' to turn on/off the lighting.
     
       press 'W' 'A' 'S' 'D' to move. 
@@ -227,7 +250,7 @@ void keyboard(unsigned char key, int x, int y){
         case 'o': // save screenshot
             saveScreenShot();
             break;
-        case 'r':
+        case 'c':
             scene.camera -> aspect_default = float(glutGet(GLUT_WINDOW_WIDTH))/float(glutGet(GLUT_WINDOW_HEIGHT));
             scene.camera -> reset();
             glutPostRedisplay();
@@ -324,6 +347,12 @@ void keyboard(unsigned char key, int x, int y){
                 glutSetCursor(GLUT_CURSOR_INHERIT);
             }
             break;
+
+        // Key for telling server that player is ready for another match
+        case 'r':
+            sendReplayToServer();         
+            break;
+
         default:
             //glutPostRedisplay();
             break;
@@ -459,12 +488,35 @@ void idle() {
 
     // Only get data from server once the client has registered with the server
     if (clientId != cse125constants::DEFAULT_CLIENT_ID) {
-        // Get data from server and allocate a new frame variable
-        cse125framing::ServerFrame* frame = receiveDataFromServer();
-        // Use the frame to update the player's state
-        updatePlayerState(frame);
-        // Delete the frame
-        delete frame;       
+        if (matchInProgress) {
+            // Get data from server and allocate a new frame variable
+            cse125framing::ServerFrame* frame = receiveDataFromServer();
+            if (frame->matchInProgress) {
+                // Use the frame to update the player's state
+                updatePlayerState(frame);
+            }
+            else {
+               cse125debug::log(LOG_LEVEL_INFO, "Match has ended!\n");
+               // The match has ended
+               matchInProgress = false;
+            }
+            // Delete the frame
+            delete frame;
+        }
+        else {
+            // Check for a packet from the server indicating that the game is ready to restart
+            if (readyToReplay) {
+                cse125debug::log(LOG_LEVEL_INFO, "Waiting for restart packet from server...\n");
+                cse125framing::ServerFrame* frame = receiveDataFromServer();
+                if (frame->matchInProgress) {
+                    cse125debug::log(LOG_LEVEL_INFO, "Ready to replay!\n");
+                    matchInProgress = true;
+                    readyToReplay = false;
+                }          
+                delete frame;
+
+            }
+        }
     }
 
     if (render) {
@@ -523,18 +575,12 @@ int main(int argc, char** argv)
 
     // Read in config file and set variables
     cse125config::initializeConfig("../../config.json");
-    /*
-    outgoingResolver = std::make_unique<boost::asio::ip::tcp::resolver>(outgoingContext);
-    outgoingEndpoints = outgoingResolver->resolve(cse125config::SERVER_HOST, cse125config::SERVER_PORT);
-    outgoingSocket = std::make_unique<boost::asio::ip::tcp::socket>(outgoingContext);
-    boost::asio::connect(*outgoingSocket, outgoingEndpoints);
-    requestClientId();
-    */
 
     // Initialize the network client
     networkClient = std::make_unique<cse125networkclient::NetworkClient>(cse125config::SERVER_HOST, cse125config::SERVER_PORT);
     // Connect to the server and set the client's id
     clientId = networkClient->getId();
+    matchInProgress = true;
     
     // Graphics binding
     initialize();


### PR DESCRIPTION
This update implements restarting a game for both the server and client. This was tested with 1 client and 4 clients on my computer. Please give it a try and let me know if it works.

- The 'r' key is used to restart the game. Previously this key was used to reset the camera, but now the key for resetting the camera is 'c'.
- Since we don't have a game ending screen yet, once you press 'r' to restart while other players have not yet, your window will freeze until all other players have pressed restart.

